### PR TITLE
fix: use https content URL, correct MIME types and CSV header

### DIFF
--- a/features/base/src/main/java/com/metinkale/prayer/App.kt
+++ b/features/base/src/main/java/com/metinkale/prayer/App.kt
@@ -82,7 +82,7 @@ open class App : Application(), OnSharedPreferenceChangeListener {
     }
 
     companion object {
-        const val API_URL = "http://metinkale38.github.io/prayer-times-android"
+        const val API_URL = "https://metinkale38.github.io/prayer-times-android"
 
         private lateinit var INSTANCE: App
 

--- a/features/base/src/main/java/com/metinkale/prayer/utils/AboutShortcuts.kt
+++ b/features/base/src/main/java/com/metinkale/prayer/utils/AboutShortcuts.kt
@@ -33,7 +33,7 @@ object AboutShortcuts {
         val sendIntent = Intent()
         sendIntent.action = Intent.ACTION_SEND
         sendIntent.putExtra(Intent.EXTRA_TEXT, ctx.getString(R.string.shareText))
-        sendIntent.type = "name/plain"
+        sendIntent.type = "text/plain"
         ctx.startActivity(sendIntent)
     }
 

--- a/features/times/src/main/java/com/metinkale/prayer/times/utils/ExportController.kt
+++ b/features/times/src/main/java/com/metinkale/prayer/times/utils/ExportController.kt
@@ -220,7 +220,7 @@ object ExportController {
         val outputFile = File(outputDir, times.name.replace(" ", "_") + ".csv")
         if (outputFile.exists()) outputFile.delete()
         val outputStream = FileOutputStream(outputFile)
-        outputStream.write("HijriDate;Fajr;Shuruq;Dhuhr;Asr;Maghrib;Ishaa\n".toByteArray())
+        outputStream.write("Date;Fajr;Shuruq;Dhuhr;Asr;Maghrib;Ishaa\n".toByteArray())
         do {
             outputStream.write((date.toString("yyyy-MM-dd") + ";").toByteArray())
             outputStream.write(
@@ -251,7 +251,7 @@ object ExportController {
         outputStream.close()
         val shareIntent = Intent()
         shareIntent.action = Intent.ACTION_SEND
-        shareIntent.type = "name/csv"
+        shareIntent.type = "text/csv"
         val uri: Uri = FileProvider.getUriForFile(
             ctx, ctx.getString(R.string.FILE_PROVIDER_AUTHORITIES), outputFile
         )


### PR DESCRIPTION
Three small fixes:

1. **`App.kt`** — the content API URL used `http://` (cleartext). Android 9+ blocks cleartext traffic by default, so downloads silently fail on modern devices. The https endpoint is served by the same GitHub Pages site, so switching to `https://` requires no other change.
2. **Invalid share MIME types** — `ExportController.kt` used `name/csv` and `AboutShortcuts.kt` used `name/plain`, neither of which is a valid MIME type (Android shares nothing with these). Changed to `text/csv` and `text/plain`.
3. **`ExportController.kt`** — the CSV header says `HijriDate`, but each row writes the Gregorian date via `date.toString("yyyy-MM-dd")`. Renamed the column to `Date`.

No behavior changes beyond the intended fixes.