### PR TITLE
Loop alarm sound until dismissed instead of playing once

### DIFF
--- a/app/src/main/java/com/metinkale/prayer/times/alarm/AlarmService.kt
+++ b/app/src/main/java/com/metinkale/prayer/times/alarm/AlarmService.kt
@@ -58,7 +58,7 @@ class AlarmService : IntentService("AlarmService") {
                         PowerManager.PARTIAL_WAKE_LOCK,
                         "prayer-times:AlarmService"
                     )
-                    wakeLock.acquire(10 * 60 * 1000L /*10 minutes*/)
+                    wakeLock.acquire(MAX_ALARM_DURATION_MS)
 
                     try {
                         runBlocking { fireAlarm(alarmId, time) }
@@ -96,17 +96,26 @@ class AlarmService : IntentService("AlarmService") {
                 delay(1000)
             }
             try {
-                player.play()
+                sInterrupt.set(false)
                 if (Preferences.STOP_ALARM_ON_FACEDOWN) {
                     StopByFacedownMgr.start(this, player)
                 }
-                sInterrupt.set(false)
-                while (!sInterrupt.get() && player.isPlaying) {
-                    delay(500)
-                }
-                if (player.isPlaying) {
+                // Keep re-playing the alarm sound until the user dismisses it
+                // (via the notification/popup) or the face-down sensor stops it.
+                // Capped at MAX_ALARM_DURATION_MS, matching the wake lock above,
+                // so it eventually falls silent if nobody is around to stop it.
+                val deadline = System.currentTimeMillis() + MAX_ALARM_DURATION_MS
+                while (!sInterrupt.get() && System.currentTimeMillis() < deadline) {
+                    player.play()
+                    if (!player.isPlaying) break // sound failed to load/start
+                    while (!sInterrupt.get() && player.isPlaying && System.currentTimeMillis() < deadline) {
+                        delay(500)
+                    }
                     player.stop()
                 }
+                // Mark the session as over even if we merely hit the deadline,
+                // so listeners like StopByFacedownMgr know to stop watching.
+                sInterrupt.set(true)
             } catch (e: Exception) {
                 recordException(e)
             }
@@ -136,8 +145,25 @@ class AlarmService : IntentService("AlarmService") {
     companion object {
         private const val EXTRA_ALARMID = "alarmId"
         private const val EXTRA_TIME = "time"
+
+        // Maximum time the alarm sound is allowed to keep repeating if nobody
+        // dismisses it. Also used as the wake lock duration in onHandleIntent.
+        private const val MAX_ALARM_DURATION_MS = 10 * 60 * 1000L
+
         private val sInterrupt = AtomicBoolean(false)
         private var sLastSchedule: Pair<Alarm, LocalDateTime>? = null
+
+        // Called from outside this class (e.g. StopByFacedownMgr) to stop the
+        // alarm loop for good, the same way StopAlarmPlayerReceiver does.
+        fun interrupt() {
+            sInterrupt.set(true)
+        }
+
+        // True once the current alarm session has been told to stop (or has
+        // ended on its own). Used by StopByFacedownMgr to know when to stop
+        // listening, since the player briefly stops between repeat cycles
+        // even while the alarm is still active.
+        fun isInterrupted(): Boolean = sInterrupt.get()
 
         fun setAlarm(c: Context, alarm: Pair<Alarm, LocalDateTime>?) {
             val am = MyAlarmManager.with(c)

--- a/app/src/main/java/com/metinkale/prayer/times/alarm/StopByFacedownMgr.kt
+++ b/app/src/main/java/com/metinkale/prayer/times/alarm/StopByFacedownMgr.kt
@@ -29,7 +29,10 @@ class StopByFacedownMgr private constructor(
 ) : SensorEventListener {
     private var isFaceDown = 1
     override fun onSensorChanged(event: SensorEvent) {
-        if (!player.isPlaying) {
+        // Note: the player is intentionally checked via AlarmService.isInterrupted()
+        // rather than player.isPlaying, since the alarm now repeats in a loop and
+        // briefly stops playing between cycles while still very much active.
+        if (AlarmService.isInterrupted()) {
             sensorManager.unregisterListener(this)
             return
         }
@@ -37,6 +40,7 @@ class StopByFacedownMgr private constructor(
             if (isFaceDown != 1) { //ignore if already was off
                 isFaceDown += 2
                 if (isFaceDown >= 15) { //prevent accident
+                    AlarmService.interrupt()
                     player.stop()
                     sensorManager.unregisterListener(this)
                 }


### PR DESCRIPTION
## Summary
- The alarm sound currently plays through the configured sound list once (chained via `MediaPlayer.setNextMediaPlayer` in `MyPlayer.play()`) and then falls silent for good, regardless of whether the user actually woke up and dismissed it.
- For a wake-up alarm (e.g. suhoor/imsak), this means a user who doesn't wake during the first play-through gets no further warning — the alarm has effectively already given up.
- This PR makes `AlarmService.fireAlarm()` keep replaying the sound in a loop until the user dismisses it (notification action) or the face-down sensor stops it, capped at the same 10 minute duration already used for the wake lock, so it still falls silent eventually if nobody is around.
- `StopByFacedownMgr` now calls the new `AlarmService.interrupt()` when it stops the player, and checks `AlarmService.isInterrupted()` instead of `player.isPlaying` to decide when to unregister its sensor listener — this matters because the player now legitimately stops and restarts between repeat cycles while the alarm session is still active, so the old `!player.isPlaying` check would have unregistered the listener prematurely on the very first inter-cycle gap.

## Test plan
- [x] Built `assembleFdroidDebug` locally and confirmed the app compiles and packages successfully with these changes.
- [ ] Manual on-device test of an alarm looping until dismissed / stopped by face-down (I don't have a way to run instrumentation tests in this environment, would appreciate a sanity check from a maintainer/reviewer before merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXinxLJwSLNghh9BS3qwK7